### PR TITLE
Escape from replaceUnitIDsWithLabels() if no units

### DIFF
--- a/simplyedit.js
+++ b/simplyedit.js
@@ -648,6 +648,10 @@ mw.loader.using("@wikimedia/codex").then(function (require) {
        * tag created for it with the label.
        */
       function replaceUnitIDsWithLabels() {
+      	if (allUnitIDs.size == 0) {
+      		return;
+      	}
+
         var api = new mw.Api();
         var lang = mw.config.get("wgUserLanguage");
         var requestParams = {


### PR DESCRIPTION
Fixes a JS error.